### PR TITLE
Remove unnecessary artefacts after building lua

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,10 @@ RUN apt-get update && \
     echo "${LUA_HASH} lua-${LUA_VERSION}.tar.gz" | md5sum -c - && \
     tar zxf lua-${LUA_VERSION}.tar.gz && \
     cd lua-${LUA_VERSION} && \
-    make linux test && make install && \
-    cd .. && rm -rf *.tar.gz lua-${LUA_VERSION} && \
+    make linux test && \
+    make install && \
+    cd .. && \
+    rm -rf *.tar.gz lua-${LUA_VERSION} && \
     apt-get purge -y --auto-remove build-essential curl libreadline-dev
 
 CMD ["/usr/local/bin/lua"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,17 @@
 FROM debian:jessie
 MAINTAINER Nicholas Iaquinto <nickiaq@gmail.com>
 
-RUN apt-get update && \
-    apt-get install -y build-essential curl zip unzip libreadline-dev && \
-    mkdir /usr/bin/lua
 
-WORKDIR /usr/bin/lua
 ENV LUA_HASH 913fdb32207046b273fdb17aad70be13
 ENV LUA_MAJOR_VERSION 5.2
 ENV LUA_MINOR_VERSION 4
 ENV LUA_VERSION ${LUA_MAJOR_VERSION}.${LUA_MINOR_VERSION}
-RUN echo "${LUA_HASH} lua-${LUA_VERSION}.tar.gz" > lua-${LUA_VERSION}.md5 && \
+
+RUN apt-get update && \
+    apt-get install -y build-essential curl zip unzip libreadline-dev && \
+    mkdir /usr/bin/lua && \
+    cd /usr/bin/lua && \
+    echo "${LUA_HASH} lua-${LUA_VERSION}.tar.gz" > lua-${LUA_VERSION}.md5 && \
     curl -R -O http://www.lua.org/ftp/lua-${LUA_VERSION}.tar.gz && \
     md5sum -c lua-${LUA_VERSION}.md5 && \
     tar zxf lua-${LUA_VERSION}.tar.gz && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
     mkdir /usr/src/lua && \
     cd /usr/src/lua && \
-    curl -R -O http://www.lua.org/ftp/lua-${LUA_VERSION}.tar.gz && \
+    curl -fSLO http://www.lua.org/ftp/lua-${LUA_VERSION}.tar.gz && \
     echo "${LUA_HASH} lua-${LUA_VERSION}.tar.gz" | md5sum -c - && \
     tar zxf lua-${LUA_VERSION}.tar.gz && \
     make -C lua-${LUA_VERSION} linux test && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,8 @@ ENV LUA_VERSION ${LUA_MAJOR_VERSION}.${LUA_MINOR_VERSION}
 RUN apt-get update && \
     apt-get install -y build-essential curl libreadline-dev && \
     rm -rf /var/lib/apt/lists/* && \
-    mkdir /usr/bin/lua && \
-    cd /usr/bin/lua && \
+    mkdir /usr/src/lua && \
+    cd /usr/src/lua && \
     echo "${LUA_HASH} lua-${LUA_VERSION}.tar.gz" > lua-${LUA_VERSION}.md5 && \
     curl -R -O http://www.lua.org/ftp/lua-${LUA_VERSION}.tar.gz && \
     md5sum -c lua-${LUA_VERSION}.md5 && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
 FROM debian:jessie
 MAINTAINER Nicholas Iaquinto <nickiaq@gmail.com>
 
-
 ENV LUA_HASH 913fdb32207046b273fdb17aad70be13
 ENV LUA_MAJOR_VERSION 5.2
 ENV LUA_MINOR_VERSION 4
 ENV LUA_VERSION ${LUA_MAJOR_VERSION}.${LUA_MINOR_VERSION}
 
 RUN apt-get update && \
-    apt-get install -y build-essential curl zip unzip libreadline-dev && \
+    apt-get install -y build-essential curl libreadline-dev && \
+    rm -rf /var/lib/apt/lists/* && \
     mkdir /usr/bin/lua && \
     cd /usr/bin/lua && \
     echo "${LUA_HASH} lua-${LUA_VERSION}.tar.gz" > lua-${LUA_VERSION}.md5 && \
@@ -17,6 +17,7 @@ RUN apt-get update && \
     tar zxf lua-${LUA_VERSION}.tar.gz && \
     cd lua-${LUA_VERSION} && \
     make linux test && make install && \
-    cd .. && rm -rf *.tar.gz *.md5 lua-${LUA_VERSION}
+    cd .. && rm -rf *.tar.gz *.md5 lua-${LUA_VERSION} && \
+    apt-get purge -y --auto-remove build-essential curl libreadline-dev
 
 CMD ["/usr/local/bin/lua"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,8 @@ RUN apt-get update && \
     curl -R -O http://www.lua.org/ftp/lua-${LUA_VERSION}.tar.gz && \
     echo "${LUA_HASH} lua-${LUA_VERSION}.tar.gz" | md5sum -c - && \
     tar zxf lua-${LUA_VERSION}.tar.gz && \
-    cd lua-${LUA_VERSION} && \
-    make linux test && \
-    make install && \
-    cd .. && \
+    make -C lua-${LUA_VERSION} linux test && \
+    make -C lua-${LUA_VERSION} install && \
     rm -rf *.tar.gz lua-${LUA_VERSION} && \
     apt-get purge -y --auto-remove build-essential curl libreadline-dev
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM buildpack-deps:jessie-scm
+FROM debian:jessie
 MAINTAINER Nicholas Iaquinto <nickiaq@gmail.com>
 
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y build-essential zip unzip libreadline-dev && \
+    apt-get install -y build-essential curl zip unzip libreadline-dev && \
     apt-get clean && \
     mkdir /usr/bin/lua
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,7 @@ FROM debian:jessie
 MAINTAINER Nicholas Iaquinto <nickiaq@gmail.com>
 
 RUN apt-get update && \
-    apt-get upgrade -y && \
     apt-get install -y build-essential curl zip unzip libreadline-dev && \
-    apt-get clean && \
     mkdir /usr/bin/lua
 
 WORKDIR /usr/bin/lua

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,13 +11,12 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
     mkdir /usr/src/lua && \
     cd /usr/src/lua && \
-    echo "${LUA_HASH} lua-${LUA_VERSION}.tar.gz" > lua-${LUA_VERSION}.md5 && \
     curl -R -O http://www.lua.org/ftp/lua-${LUA_VERSION}.tar.gz && \
-    md5sum -c lua-${LUA_VERSION}.md5 && \
+    echo "${LUA_HASH} lua-${LUA_VERSION}.tar.gz" | md5sum -c - && \
     tar zxf lua-${LUA_VERSION}.tar.gz && \
     cd lua-${LUA_VERSION} && \
     make linux test && make install && \
-    cd .. && rm -rf *.tar.gz *.md5 lua-${LUA_VERSION} && \
+    cd .. && rm -rf *.tar.gz lua-${LUA_VERSION} && \
     apt-get purge -y --auto-remove build-essential curl libreadline-dev
 
 CMD ["/usr/local/bin/lua"]


### PR DESCRIPTION
This pull request combines all build steps in one step and removes the used packages right after compiling.

The final image got reduced from 332MB to 135.7MB.